### PR TITLE
Make Rubocop compliant

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,1 @@
-require "bundler/gem_tasks"
-
+require 'bundler/gem_tasks'

--- a/git_version_bumper.gemspec
+++ b/git_version_bumper.gemspec
@@ -4,32 +4,32 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'git_version_bumper/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "git_version_bumper"
+  spec.name          = 'git_version_bumper'
   spec.version       = GitVersionBumper::VERSION
-  spec.authors       = ["Troy Rosenberg"]
-  spec.email         = ["tmr08c@gmail.com"]
-  spec.summary       = %q{CLI tool to create version bump commit and tag with
-                          newest version in a Git repository.}
-  spec.description   = %q{CLI tool to create version bump commit and tag with
+  spec.authors       = ['Troy Rosenberg']
+  spec.email         = ['tmr08c@gmail.com']
+  spec.summary       = 'CLI tool to create version bump commit and tag with
+                          newest version in a Git repository.'
+  spec.description   = 'CLI tool to create version bump commit and tag with
                           newest version in a Git repository. Versioning is
                           based on [Semantic Versioning](http://semver.org/).
                           Version bump types include MAJOR, MINOR, and PATCH.
                           Once installed gem can be used in a Git repository by
-                          running `versionify bump TYPE` }
-  spec.homepage      = "https://github.com/tmr08c/git_version_bumper/"
-  spec.license       = "MIT"
+                          running `versionify bump TYPE` '
+  spec.homepage      = 'https://github.com/tmr08c/git_version_bumper/'
+  spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency     "git", "~> 1.2"
-  spec.add_runtime_dependency     "thor", "~> 0.19"
+  spec.add_runtime_dependency     'git', '~> 1.2'
+  spec.add_runtime_dependency     'thor', '~> 0.19'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
-  spec.add_development_dependency "debugger"
-  spec.add_development_dependency "rubocop", "~> 0.36"
+  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'debugger'
+  spec.add_development_dependency 'rubocop', '~> 0.36'
 end

--- a/git_version_bumper.gemspec
+++ b/git_version_bumper.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "debugger"
+  spec.add_development_dependency "rubocop", "~> 0.36"
 end

--- a/lib/git_version_bumper.rb
+++ b/lib/git_version_bumper.rb
@@ -5,6 +5,6 @@ require 'git_version_bumper/version_bumper/major_version_bumper'
 require 'git_version_bumper/version_bumper/minor_version_bumper'
 require 'git_version_bumper/version_bumper/patch_version_bumper'
 
+# Module to namespace logic that is a part of the GitVersionBumper gem
 module GitVersionBumper
-  # Your code goes here...
 end

--- a/lib/git_version_bumper/cli.rb
+++ b/lib/git_version_bumper/cli.rb
@@ -1,6 +1,8 @@
 require 'thor'
 
 module GitVersionBumper
+  # Handles logic associated with command line interface.
+  # Uses Thor to make interaction more pleasant.
   class CLI < Thor
     SUCCESS_EXIT_STATUS = 0
     ERROR_EXIT_STATUS = 1
@@ -14,7 +16,7 @@ module GitVersionBumper
       MAJOR_VERSION_TYPE,
       MINOR_VERSION_TYPE,
       PATCH_VERSION_TYPE
-    ]
+    ].freeze
 
     desc(
       'bump TYPE',

--- a/lib/git_version_bumper/version.rb
+++ b/lib/git_version_bumper/version.rb
@@ -1,3 +1,3 @@
 module GitVersionBumper
-  VERSION = "0.0.1"
+  VERSION = '0.0.1'.freeze
 end

--- a/lib/git_version_bumper/version_bumper/bumper.rb
+++ b/lib/git_version_bumper/version_bumper/bumper.rb
@@ -1,4 +1,6 @@
 require 'git_version_bumper'
+require 'git_version_bumper/version_bumper/null_tag'
+require 'git'
 
 module GitVersionBumper
   module VersionBumper

--- a/lib/git_version_bumper/version_bumper/bumper.rb
+++ b/lib/git_version_bumper/version_bumper/bumper.rb
@@ -50,7 +50,7 @@ module GitVersionBumper
       def git_object(path)
         Git.open(path)
       rescue ArgumentError
-        fail Errors::NotRepositoryError
+        raise Errors::NotRepositoryError
       end
     end
   end

--- a/lib/git_version_bumper/version_bumper/bumper.rb
+++ b/lib/git_version_bumper/version_bumper/bumper.rb
@@ -2,6 +2,11 @@ require 'git_version_bumper'
 
 module GitVersionBumper
   module VersionBumper
+    # Parent class used for housing logic on how to handle increasing version
+    # number. This includes creating and tagging a version bump commit.
+    #
+    # This should be inheirted from to implement the logic for creating the
+    # `tag` associated with the new version.
     class Bumper
       VERSION_BUMP_COMMIT_MESSAGE = 'Version Bump.'.freeze
 

--- a/lib/git_version_bumper/version_bumper/major_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/major_version_bumper.rb
@@ -1,7 +1,4 @@
-require 'git_version_bumper'
 require 'git_version_bumper/version_bumper/bumper'
-require 'git_version_bumper/version_bumper/null_tag'
-require 'git'
 
 module GitVersionBumper
   module VersionBumper

--- a/lib/git_version_bumper/version_bumper/major_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/major_version_bumper.rb
@@ -5,6 +5,7 @@ require 'git'
 
 module GitVersionBumper
   module VersionBumper
+    # Implementation of Bumper that increases the major version number.
     class MajorVersionBumper < Bumper
       private
 

--- a/lib/git_version_bumper/version_bumper/major_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/major_version_bumper.rb
@@ -6,7 +6,6 @@ require 'git'
 module GitVersionBumper
   module VersionBumper
     class MajorVersionBumper < Bumper
-
       private
 
       def tag

--- a/lib/git_version_bumper/version_bumper/minor_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/minor_version_bumper.rb
@@ -1,4 +1,3 @@
-require 'git_version_bumper'
 require 'git_version_bumper/version_bumper/bumper'
 
 module GitVersionBumper

--- a/lib/git_version_bumper/version_bumper/minor_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/minor_version_bumper.rb
@@ -2,6 +2,7 @@ require 'git_version_bumper/version_bumper/bumper'
 
 module GitVersionBumper
   module VersionBumper
+    # Implementation of Bumper that increases the minor version number.
     class MinorVersionBumper < Bumper
       private
 

--- a/lib/git_version_bumper/version_bumper/null_tag.rb
+++ b/lib/git_version_bumper/version_bumper/null_tag.rb
@@ -1,5 +1,6 @@
 module GitVersionBumper
   module VersionBumper
+    # Null Object represenation of Git::Object::Tag
     class NullTag
       def initialize; end
 

--- a/lib/git_version_bumper/version_bumper/patch_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/patch_version_bumper.rb
@@ -1,4 +1,3 @@
-require 'git_version_bumper'
 require 'git_version_bumper/version_bumper/bumper'
 
 module GitVersionBumper

--- a/lib/git_version_bumper/version_bumper/patch_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/patch_version_bumper.rb
@@ -2,6 +2,7 @@ require 'git_version_bumper/version_bumper/bumper'
 
 module GitVersionBumper
   module VersionBumper
+    # Implementation of Bumper that increases the patch version number.
     class PatchVersionBumper < Bumper
       private
 

--- a/lib/git_version_bumper/version_bumper/patch_version_bumper.rb
+++ b/lib/git_version_bumper/version_bumper/patch_version_bumper.rb
@@ -8,7 +8,9 @@ module GitVersionBumper
 
       def tag
         git.add_tag(
-          "v#{current_major_version}.#{current_minor_version}.#{current_patch_version + 1}"
+          "v#{current_major_version}." \
+          "#{current_minor_version}." \
+          "#{current_patch_version + 1}"
         )
       end
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -7,7 +7,7 @@ describe GitVersionBumper::CLI do
       subject { described_class.new }
 
       it 'should error' do
-        expect{ subject.bump }.to raise_error(ArgumentError)
+        expect { subject.bump }.to raise_error(ArgumentError)
       end
     end
 
@@ -28,7 +28,10 @@ describe GitVersionBumper::CLI do
         context 'when the type is PATCH' do
           let(:type) { 'PATCH' }
           let(:bumper) do
-            instance_double(GitVersionBumper::VersionBumper::PatchVersionBumper, bump: true)
+            instance_double(
+              GitVersionBumper::VersionBumper::PatchVersionBumper,
+              bump: true
+            )
           end
 
           it 'should use a PatchVersionBumper' do
@@ -45,7 +48,10 @@ describe GitVersionBumper::CLI do
         context 'when the type is MINOR' do
           let(:type) { 'MINOR' }
           let(:bumper) do
-            instance_double(GitVersionBumper::VersionBumper::MinorVersionBumper, bump: true)
+            instance_double(
+              GitVersionBumper::VersionBumper::MinorVersionBumper,
+              bump: true
+            )
           end
 
           it 'should use a MinorVersionBumper' do
@@ -61,7 +67,12 @@ describe GitVersionBumper::CLI do
 
         context 'when the type is MAJOR' do
           let(:type) { 'MAJOR' }
-          let(:bumper) { instance_double(GitVersionBumper::VersionBumper::MajorVersionBumper, bump: true) }
+          let(:bumper) do
+            instance_double(
+              GitVersionBumper::VersionBumper::MajorVersionBumper,
+              bump: true
+            )
+          end
 
           it 'should user a MajorVersionBumper' do
             expect(GitVersionBumper::VersionBumper::MajorVersionBumper)
@@ -106,21 +117,15 @@ describe GitVersionBumper::CLI do
       subject { described_class.new }
       let(:bumper) { double('bumper', bump: true) }
 
-      before do
-        path = '/tmp/testRepo'
-        FileUtils.mkdir_p(path)
-        FileUtils.chdir(path)
-        %x(git init)
-      end
-
       it 'should return a successful exit status' do
-        expect(subject).to receive(:bumper_for).with('MAJOR').and_return(bumper)
+        with_repo do
+          expect(subject)
+            .to receive(:bumper_for)
+            .with('MAJOR')
+            .and_return(bumper)
 
-        expect(subject.bump('MAJOR')).to eq 0
-      end
-
-      after do
-        FileUtils.chdir(File.realpath("#{__FILE__}/.."))
+          expect(subject.bump('MAJOR')).to eq 0
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,9 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
+
+# rubocop:disable Style/BlockComments
+
 =begin
   # These two settings work together to allow you to limit a spec run
   # to individual examples or groups you care about by tagging them with
@@ -93,6 +96,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
+  # rubocop:enable Style/BlockComments
 
   def with_repo(path = 'tmp/testRepo')
     FileUtils.mkdir_p(path)


### PR DESCRIPTION
Makes everything but `exe_spec` Rubocop compliant. Leaving `exe_spec` for #2