### PR TITLE
Updates version requirements in gemspec.

### DIFF
--- a/git_version_bumper.gemspec
+++ b/git_version_bumper.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     'thor', '~> 0.19'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rake', '~> 10'
+  spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'rubocop', '~> 0.36'
 end


### PR DESCRIPTION
Previously we were leaving the version for the development dependencies
`rake` and `rspec` open ended. This change updates the gemspec to
specify minimum versions for these gems.